### PR TITLE
fix: text wrapping in EventContent

### DIFF
--- a/apps/web/src/lib/components/EventContent.svelte
+++ b/apps/web/src/lib/components/EventContent.svelte
@@ -32,7 +32,7 @@
     }
 </script>
 
-<div class="prose flex flex-col items-start gap-4 text-zinc-600 dark:text-zinc-400 font-serif text-lg leading-9">
+<div class="prose items-start gap-4 text-zinc-600 dark:text-zinc-400 font-serif text-lg leading-9">
     <EventContent
         ndk={$ndk}
         content={md.render(event.content)}


### PR DESCRIPTION
Currently wiki entries are unreadable on mobile (and a lot of web clients as well) as the container forces a scroll.

This PR removes the `flex` class on the wrapper of `EventContent` so the text wraps properly

Before
![Screenshot from 2024-05-31 08-32-59](https://github.com/pablof7z/wiki/assets/9901863/6244bcdd-36f0-42ed-a0b4-89fee64ff56f)

After
![Screenshot from 2024-05-31 08-33-15](https://github.com/pablof7z/wiki/assets/9901863/8f979f80-7253-45a9-990e-4c0d2d1da1d2)

